### PR TITLE
Homme, SL and pg2: Little mods and tests.

### DIFF
--- a/components/homme/src/interpolate_driver_mod.F90
+++ b/components/homme/src/interpolate_driver_mod.F90
@@ -1191,14 +1191,14 @@ contains
 
     use element_mod, only: element_t
     use parallel_mod, only: parallel_t
+    use kinds, only: real_kind
+    use dimensions_mod, only: nelemd, nlev, np, npsq
+    use common_io_mod, only: varname_len
 #ifndef HOMME_WITHOUT_PIOLIBRARY
     use dof_mod, only: putuniquepoints
-    use kinds, only: real_kind
     use edge_mod, only: edgevpack, edgevunpack, initedgebuffer, freeedgebuffer
     use edgetype_mod, only: edgebuffer_t
-    use dimensions_mod, only: nelemd, nlev, np, npsq
     use bndry_mod, only: bndry_exchangeV
-    use common_io_mod, only: varname_len
 #endif
 
     character(len=*), intent(in) :: filename
@@ -1267,10 +1267,10 @@ contains
   subroutine read_physgrid_topo_file(infilename, elem, par, fieldnames, nphys, pg_fields, stat)
     use element_mod, only: element_t
     use parallel_mod, only: parallel_t
-#ifndef HOMME_WITHOUT_PIOLIBRARY
     use kinds, only: real_kind
-    use dimensions_mod, only: nelemd, nlev, np, npsq, nelem
     use common_io_mod, only: varname_len, io_stride, num_io_procs, num_agg
+#ifndef HOMME_WITHOUT_PIOLIBRARY
+    use dimensions_mod, only: nelemd, nlev, np, npsq, nelem
     use control_mod, only: max_string_len
     use pio, only: pio_init, pio_openfile, pio_rearr_box, pio_inquire, pio_inq_dimname, &
          pio_inq_dimlen, pio_initdecomp
@@ -1355,10 +1355,10 @@ contains
 
     use element_mod, only: element_t
     use parallel_mod, only: parallel_t
-#ifndef HOMME_WITHOUT_PIOLIBRARY
     use kinds, only: real_kind
     use dimensions_mod, only: nelemd, nlev, np, npsq, nelem
     use common_io_mod, only: varname_len
+#ifndef HOMME_WITHOUT_PIOLIBRARY
     use pio_io_mod, only: nf_output_init_complete, nf_output_register_variables, nf_put_var_pio
     use control_mod, only: max_string_len
 #endif
@@ -1440,9 +1440,9 @@ contains
        gll_fields, pg_fields, nphys, history, output_latlon)
     use element_mod, only: element_t
     use parallel_mod, only: parallel_t
-#ifndef HOMME_WITHOUT_PIOLIBRARY
     use kinds, only: real_kind
     use dimensions_mod, only: nelemd, nlev, np, npsq, nelem
+#ifndef HOMME_WITHOUT_PIOLIBRARY
     use common_io_mod, only: varname_len
     use pio_io_mod, only: nf_output_init_complete, nf_output_register_variables, nf_put_var_pio
     use control_mod, only: max_string_len

--- a/components/homme/src/share/gllfvremap_mod.F90
+++ b/components/homme/src/share/gllfvremap_mod.F90
@@ -182,7 +182,7 @@ contains
     if (present(check)) gfr%check = check
 
     gfr%boost_pg1 = .false.
-    if (present(boost_pg1)) gfr%boost_pg1 = boost_pg1    
+    if (nphys == 1 .and. present(boost_pg1)) gfr%boost_pg1 = boost_pg1    
 
     gfr%tolfac = one
     if (par%masterproc) then

--- a/components/homme/src/share/sl_advection.F90
+++ b/components/homme/src/share/sl_advection.F90
@@ -157,7 +157,7 @@ contains
     if (independent_time_steps) then
        call t_startf('SLMM_reconstruct')
        if (dp_tol < zero) then
-          ! Thread write race condition; benign b/c written value is same in all threads.
+          ! benign write race condition
           call set_dp_tol(hvcoord, dp_tol)
        end if
        do ie = nets,nete
@@ -242,7 +242,9 @@ contains
        call t_startf('CEDR_local')
        call cedr_sl_run_local(minq, maxq, nets, nete, scalar_q_bounds, limiter_option)
        ! Barrier needed to protect edge_g buffers use in CEDR.
+#if (defined HORIZ_OPENMP)
        !$omp barrier
+#endif
        if (barrier) call perf_barrier(hybrid)
        call t_stopf('CEDR_local')
     else
@@ -755,10 +757,68 @@ contains
 
   subroutine calc_vertically_lagrangian_levels( &
        hybrid, elem, ie, hvcoord, tl, dt, deriv, dp_tol, dprecon)
-    ! Reconstruct the vertically Lagrangian levels, thus permitting
-    ! the dynamics vertical remap time step to be shorter than the
-    ! tracer time step.
 
+    ! Reconstruct the vertically Lagrangian levels, thus permitting the dynamics
+    ! vertical remap time step to be shorter than the tracer time step.
+    !   Recall
+    !     p(eta,ps) = A(eta) p0 + B(eta) ps
+    !     => dp/dt = p_eta deta/dt + p_ps dps/dt
+    !              = (A_eta p0 + B_eta ps) deta/dt + B(eta) dps/dt
+    ! dp3d already accounts for B(eta) dps/dt, so it does not appear in what
+    ! follows. We use eta as the vertical coordinate in these calculations. But
+    ! here, to focus on the key ideas, consider a p = (x,z) system with
+    ! velocities v = (u,w). Let 0, h, 1, suffixes denote start, middle, and end
+    ! of the time step. The algorithm is as follows.
+    !   The trajectory is computed forward in time, so the departure 0 points
+    ! are on the grid. We need to compute z(x0,t1), the floating height at
+    ! horizontal grid point x0 at time t1. We start by computing z1 = z(x1,t1),
+    ! the floating height at the non-grid point x1 at time t1 or, in other
+    ! words, the non-grid arrival point:
+    !     z1 = z0 + dt w(ph,th) + O(dt^3)
+    !     xh - x0 = dt/2 u(p0,th) + O(dt^2)
+    !     zh - z0 = dt/2 w(p0,th) + O(dt^2)
+    !     w(ph,th) = w(p0,th) + w_x(p0,th) (xh - x0) + O(|xh - x0|^2)
+    !                         + w_z(p0,th) (zh - z0) + O(|zh - z0|^2)
+    !              = w(p0,th) + dt/2 (  w_x(p0,th) u(p0,th)
+    !                                 + w_z(p0,th) w(p0,th)) + O(dt^2)
+    !     z1 = z0 + dt (w(p0,th) + dt/2 (  w_x(p0,th) u(p0,th)
+    !                                    + w_z(p0,th) w(p0,th))) + O(dt^3)   (*)
+    ! Now we compute z(x0,t1). First, we need
+    !     x0 - x1 = -dt u(ph,th) + O(dt^3)
+    ! and
+    !     z_x(x1,t1) = z0_x + dt w_x(p0,th) + O(dt^2)
+    !                = dt w_x(p0,th) + O(dt^2).
+    !     z_xx(x1,t1) = z0_xx + dt w_xx(p0,th) + O(dt^2)
+    !                 = dt w_xx(p0,th) + O(dt^2).
+    ! Then we expand z(x0,t1) in Taylor series and substitute:
+    !     z(x0,t1) = z(x1,t1) + z_x(x1,t1) (x0 - x1) + z_xx(x1,t1) (x0 - x1)^2
+    !                + O(|x0 - x1|^3)
+    !              = z(x1,t1) - dt z_x(x1,t1) u(ph,th)
+    !                + dt^2 z_xx(x1,t1) u(ph,th)^2
+    !                + O(dt^3) + O(|x0 - x1|^3)
+    !              = z(x1,t1) - dt^2 w_x(p0,th) u(ph,th)
+    !                + dt^3 w_xx(x1,t1) u(ph,th)^2
+    !                + O(dt^3) + O(|x0 - x1|^3).
+    ! Gather all O(dt^3) terms, with O(|x0 - x1|^p) = O(dt^p):
+    !     z(x0,t1) = z(x1,t1) - dt^2 w_x(p0,th) u(ph,th) + O(dt^3).
+    ! Now substitute (*) for z(x1,t1):
+    !     z(x0,t1) = z0 + dt (w(p0,th) + dt/2 (  w_x(p0,th) u(p0,th)
+    !                                          + w_z(p0,th) w(p0,th)))
+    !                - dt^2 w_x(p0,th) u(ph,th) + O(dt^3)
+    !              = z0 + dt (w(p0,th) + dt/2 ( -w_x(p0,th) u(p0,th)
+    !                                          + w_z(p0,th) w(p0,th))) + O(dt^3).
+    ! This is locally accurate to O(dt^3) and so globally 2nd-order
+    ! accurate. Notably, compared with (*), this formula differs only in a
+    ! sign. Note also that a straightforward first-order accurate formula is
+    !     z(x0,t1) = z0 + dt w(p0,th) + O(dt^2).
+    !   z(x0,t1) here corresponds to the reconstructed floating eta level
+    ! eta(x_sphere, t1), where x_sphere is the horizontal grid point
+    ! position. It is denoted eta1r in the code below. Given eta1r, we can then
+    ! compute eta_dot_dpdn to O(dt^2). If we used the input eta_dot_dpdn
+    ! directly we'd have it to O(dt). The final step is to use this
+    ! reconstructed eta_dot_dpdn and dp3d to compute the floating layers
+    ! dprecon.
+    
     use control_mod, only: dt_remap_factor
     use derivative_mod, only: derivative_t, gradient_sphere
     use kinds, only: iulog
@@ -772,9 +832,10 @@ contains
     type (derivative_t), intent(in) :: deriv
     real(kind=real_kind), intent(out) :: dprecon(np,np,nlev)
 
-    real(real_kind), dimension(np,np,nlevp) :: pref, p0r, p1r, eta_dot_dpdn
-    real(real_kind), dimension(np,np) :: dps, ptp0, pth, v1h, v2h, divdp
-    real(real_kind), dimension(np,np,2) :: grad, vdp
+    real(real_kind), dimension(np,np,nlevp) :: pref, p1r, eta_dot_dpdn
+    real(real_kind), dimension(np,np) :: dpi, ps_t, divdp
+    real(real_kind), dimension(np,np,2) :: vdp, v
+    real(real_kind), dimension(np,np,3) :: grad
     real(real_kind) :: dp_neg_min
     integer :: i, j, k, k1, k2, d
 
@@ -801,86 +862,56 @@ contains
           divdp = divergence_sphere(vdp, deriv, elem)
           eta_dot_dpdn(:,:,k+1) = eta_dot_dpdn(:,:,k) + divdp
        end do
-       dps = eta_dot_dpdn(:,:,nlevp)
+       ps_t = -eta_dot_dpdn(:,:,nlevp)
        eta_dot_dpdn(:,:,nlevp) = zero
        do k = 2,nlev
-          eta_dot_dpdn(:,:,k) = hvcoord%hybi(k)*dps - eta_dot_dpdn(:,:,k)
+          ! eta_dot_dpdn
+          eta_dot_dpdn(:,:,k) = -hvcoord%hybi(k)*ps_t - eta_dot_dpdn(:,:,k)
        end do
     end if
 
-    ! Recall
-    !   p(eta,ps) = A(eta) p0 + B(eta) ps
-    !   => dp/dt = p_eta deta/dt + p_ps dps/dt
-    !            = (A_eta p0 + B_eta ps) deta/dt + B(eta) dps/dt
-    ! In what follows, we consistently drop the surface pressure time
-    ! derivative term, B(eta) dps/dt. In particular, pref is used for
-    ! both n0 and np1, even though it's computed for n0 only. At the
-    ! end, in each term of the expression (p1r - pref), there is a
-    ! missing B(eta) dps/dt term, and these missing terms cancel in
-    ! the subtraction.
-    !
-    ! The departure point algorithm is as follows. Let 0, h, 1
-    ! suffixes denote start, middle and end of the time step. A Taylor
-    ! series expansion of v at the midpoint in space and time gives
-    !   v(ph,th) a= v(p1,th) + gradv(p1,th) (ph - p1)
-    ! Approximate
-    !   ph - p1 a= -v(p1,th) dt/2
-    ! Then
-    !   (p1 - p0)/dt a= v(ph,th)
-    !                 = v(p1,th) + gradv(p1,th) (ph - p1)
-    !                a= v(p1,th) - dt/2 gradv(p1,th) v(p1,th)
-    !   => p0 := p1 - dt (v(p1,th) - dt/2 gradv(p1,th) v(p1,th))
-    ! where the final line gives the departure point at time 0.
-
+    ! Use p0 as the reference coordinate system. p0 differs from p1 by B(eta)
+    ! (ps1 - ps0); dp3d already accounts for this term
+    ! w.r.t. derived%dp. Recall
+    !     eta_dot_dpdn = p_eta eta_dot = (A_eta p0 + B_eta ps) deta/dt,
+    ! except that in the code eta_dot_dpdn is actually dp deta/dt rather than
+    ! dp/deta deta/dt. eta_dot_dpdn is the motion of a pressure level excluding
+    ! its motion due to dps/dt.
     call calc_p(hvcoord, elem%derived%dp, pref)
 
-    p0r(:,:,1) = pref(:,:,1)
-    p0r(:,:,nlevp) = pref(:,:,nlevp)
-
     do k = 2, nlev
-       ! Gradient of eta_dot_dpdn = p_eta deta/dt at initial
-       ! time w.r.t. horizontal sphere coords.
-       grad = gradient_sphere(eta_dot_dpdn(:,:,k), deriv, elem%Dinv)
+       ! Gradient of eta_dot at midpoint time w.r.t. horizontal sphere coords.
+       grad(:,:,1:2) = gradient_sphere(eta_dot_dpdn(:,:,k), deriv, elem%Dinv)
 
-       ! Gradient of eta_dot_dpdn = p_eta deta/dt at initial
-       ! time w.r.t. p at initial time.
+       ! Gradient of eta_dot at midpoint time w.r.t. vertical ref coords.
        k1 = k-1
        k2 = k+1
-       call eval_lagrange_poly_derivative(k2-k1+1, pref(:,:,k1:k2), &
-            eta_dot_dpdn(:,:,k1:k2), &
-            pref(:,:,k), ptp0)
+       call eval_lagrange_poly_derivative(k2-k1+1, &
+            pref(:,:,k1:k2), eta_dot_dpdn(:,:,k1:k2), &
+            pref(:,:,k), grad(:,:,3))
 
        ! Horizontal velocity at time midpoint.
-       k1 = k-1
-       k2 = k
-       v1h = fourth*(elem%state%v(:,:,1,k1,tl%n0 ) + elem%state%v(:,:,1,k2,tl%n0 ) + &
-                     elem%state%v(:,:,1,k1,tl%np1) + elem%state%v(:,:,1,k2,tl%np1))
-       v2h = fourth*(elem%state%v(:,:,2,k1,tl%n0 ) + elem%state%v(:,:,2,k2,tl%n0 ) + &
-                     elem%state%v(:,:,2,k1,tl%np1) + elem%state%v(:,:,2,k2,tl%np1))
-
-       ! Vertical eta_dot_dpdn at time midpoint.
-       pth = eta_dot_dpdn(:,:,k)
-
-       ! Reconstruct departure level coordinate at intial time.
-       p0r(:,:,k) = pref(:,:,k) - &
-            dt*(pth - half*dt*(ptp0*pth + grad(:,:,1)*v1h + grad(:,:,2)*v2h))
-    end do
-
-    ! Interpolate Lagrangian level in p coord to final time.
-    do j = 1,np
-       do i = 1,np
-          call interp(nlevp, p0r(i,j,:), pref(i,j,:), pref(i,j,:), p1r(i,j,:))
+       do d = 1,2
+          v(:,:,d) = fourth*(elem%derived%vstar(:,:,d,k-1) + elem%derived%vstar(:,:,d,k) + &
+                             elem%derived%vn0  (:,:,d,k-1) + elem%derived%vn0  (:,:,d,k))
        end do
-    end do
 
+       ! Reconstruct departure level coordinate at final time.
+       p1r(:,:,k) = pref(:,:,k) + dt*( &
+            eta_dot_dpdn(:,:,k) + &
+            half*dt*(-grad(:,:,1)*v(:,:,1) - grad(:,:,2)*v(:,:,2) + grad(:,:,3)*eta_dot_dpdn(:,:,k)))
+    end do
+    p1r(:,:,1) = pref(:,:,1)
+    p1r(:,:,nlevp) = pref(:,:,nlevp)
+    
     ! Reconstruct eta_dot_dpdn over the time interval.
     eta_dot_dpdn = (p1r - pref)/dt
-    ! End points are always 0.
+    ! Boundary points are always 0.
     eta_dot_dpdn(:,:,1) = zero
     eta_dot_dpdn(:,:,nlevp) = zero
 
-    ! Limit dp to be > 0 and store update in eta_dot_dpdn rather
-    ! than true eta_dot_dpdn. See comments below for more.
+    ! Limit dp to be > 0 and store update in eta_dot_dpdn rather than true
+    ! eta_dot_dpdn. See comments below for more.
     dp_neg_min = reconstruct_and_limit_dp(elem%state%dp3d(:,:,:,tl%np1), &
          dt, dp_tol, eta_dot_dpdn, dprecon)
 #ifndef NDEBUG
@@ -920,27 +951,6 @@ contains
        yp = yp + ys(:,:,i)*f
     end do
   end subroutine eval_lagrange_poly_derivative
-
-  subroutine interp(n, x, y, xi, yi)
-    integer, intent(in) :: n
-    real(kind=real_kind), intent(in) :: x(:), y(:), xi(:)
-    real(kind=real_kind), intent(out) :: yi(:)
-
-    real(kind=real_kind) :: alpha
-    integer :: j, ji
-
-    j = 1
-    ji = 1
-    do while (ji <= n)
-       if (j < n-1 .and. xi(ji) > x(j+1)) then
-          j = j + 1
-       else
-          alpha = (xi(ji) - x(j))/(x(j+1) - x(j))
-          yi(ji) = (1 - alpha)*y(j) + alpha*y(j+1)
-          ji = ji + 1
-       end if
-    end do
-  end subroutine interp
 
   subroutine calc_p(hvcoord, dp, p)
     type (hvcoord_t), intent(in) :: hvcoord

--- a/components/homme/src/test_src/dcmip16_wrapper.F90
+++ b/components/homme/src/test_src/dcmip16_wrapper.F90
@@ -650,7 +650,6 @@ subroutine dcmip2016_test1_pg_forcing(elem,hybrid,hvcoord,nets,nete,nt,ntQ,dt,tl
   call t_stopf('gfr_dyn_to_fv_phys')
 
   do ie = nets,nete
-     precl(:,:,ie) = -one
      ! for max_w
      call get_field(elem(ie), 'w', w, hvcoord, nt, ntQ)
 
@@ -690,8 +689,8 @@ subroutine dcmip2016_test1_pg_forcing(elem,hybrid,hvcoord,nets,nete,nt,ntQ,dt,tl
      rho_dry_fv(:nf,:nf,:) = (1 - Q_fv(:nf,:nf,:,iqv))*rho_fv(:nf,:nf,:)
 
      ! Compute form of exner pressure expected by Kessler physics.
-     exner_kess_fv = (p_fv/p0)**(Rgas/Cp)
-     theta_kess_fv = T_fv/exner_kess_fv
+     exner_kess_fv(:nf,:nf,:) = (p_fv(:nf,:nf,:)/p0)**(Rgas/Cp)
+     theta_kess_fv(:nf,:nf,:) = T_fv(:nf,:nf,:)/exner_kess_fv(:nf,:nf,:)
 
      u0(:nf,:nf,:) = u_fv(:nf,:nf,:); v0(:nf,:nf,:) = v_fv(:nf,:nf,:); T0(:nf,:nf,:) = T_fv(:nf,:nf,:)
      Q0_fv(:nf,:nf,:,:) = Q_fv(:nf,:nf,:,:);
@@ -714,6 +713,8 @@ subroutine dcmip2016_test1_pg_forcing(elem,hybrid,hvcoord,nets,nete,nt,ntQ,dt,tl
            zi_c = zi_fv(i,j,nlevp:1:-1)
            th_c = theta_kess_fv(i,j,nlev:1:-1)
 
+           call gfr_f_get_latlon(ie, i, j, lat, lon)
+
            ! Get forced versions of u,v,p,qv,qc,qr. rho is constant.
            call DCMIP2016_PHYSICS(test, u_c, v_c, p_c, th_c, qv_c, qc_c, qr_c, rho_c, dt, &
                 z_c, zi_c, lat, nlev, precl_fv(i,j,1), pbl_type, prec_type)
@@ -725,7 +726,6 @@ subroutine dcmip2016_test1_pg_forcing(elem,hybrid,hvcoord,nets,nete,nt,ntQ,dt,tl
            Q_fv(i,j,:,3) = qr_c(nlev:1:-1)
            theta_kess_fv(i,j,:) = th_c(nlev:1:-1)
 
-           call gfr_f_get_latlon(ie, i, j, lat, lon)
            do k=1,nlev
               call tendency_terminator(lat*rad2dg, lon*rad2dg, Q_fv(i,j,k,4), Q_fv(i,j,k,5), &
                    dt, ddt_cl(i,j,k), ddt_cl2(i,j,k))

--- a/components/homme/test/reg_test/run_tests/test-list.cmake
+++ b/components/homme/test/reg_test/run_tests/test-list.cmake
@@ -37,7 +37,7 @@ IF (${HOMME_ENABLE_COMPOSE})
   LIST(APPEND HOMME_TESTS
     thetah-sl-test11conv-r1t2-cdr20.cmake
     thetah-sl-test11conv-r0t1-cdr30-rrm.cmake
-    #thetah-sl-dcmip16_test1pg2.cmake
+    thetah-sl-dcmip16_test1pg2.cmake
     )
 ENDIF()
 

--- a/components/homme/test/reg_test/run_tests/thetah-sl-dcmip16_test1pg2.cmake
+++ b/components/homme/test/reg_test/run_tests/thetah-sl-dcmip16_test1pg2.cmake
@@ -10,4 +10,4 @@ SET(VCOORD_FILES ${HOMME_ROOT}/test/vcoord/*30*)
 
 # compare all of these files against baselines:
 SET(NC_OUTPUT_FILES 
-  dcmip2016_test1_pg2.nc)
+  dcmip2016_test1_pg21.nc)


### PR DESCRIPTION
* New SL 3D trajectory computation changes the computation of the vertical motion
to be forward in time. This removes the need for an interpolation step used in
the original backward-in-time approach.
* Fix some memory errors in the DCMIP16 test 1 pg2 forcing function, fix the nc output file name in the test cmake, and reenable test thetah-sl-dcmip16_test1pg2.

[non-BFB] for 3 Homme standalone SL tests (2 old + 1 new), 1 E3SM SL test (SMS_Ln5.ne4pg2_ne4pg2.FC5AV1C-L.machine_compiler.cam-thetahy_sl_pg2)